### PR TITLE
fix Improper Method Call: better api for creating temporary files

### DIFF
--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -58,7 +58,7 @@ def main(test_collection_file: Optional[str] = None, no_clone_repo: bool = False
         # the test configuration file. Otherwise, we might be missing newly
         # added test.
 
-        tmpdir = tempfile.mktemp()
+        tmpdir = tempfile.NamedTemporaryFile().name
 
         current_release_dir = os.path.abspath(
             os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [build_pipeline.py](https://github.com/uber/ray/blob/bc1c3787aae5685ad5296975474ec426b506afc1/release/ray_release/scripts/build_pipeline.py#L61), there is a method that creates a temporary file using an unsafe API mktemp. The use of this method is discouraged in the [Python documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp). iCR suggested that a temporary file should be created using NamedTemporaryFile() which is a [safe API](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile). iCR replaced the usage of mktemp with NamedTemporaryFile.

<!-- ## Related issue number -->

<!-- For example: "Closes #1234" -->

## Changes
* Replaced `mktemp()` method with `NamedTemporaryFile()`

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## Sponsorship and Support

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.